### PR TITLE
Some stuff

### DIFF
--- a/ftplugin/sy.vim
+++ b/ftplugin/sy.vim
@@ -1,0 +1,21 @@
+" Sylt filetype plugin file
+" Language: Sylt
+
+" Avoid loading multiple filetypes
+if exists("b:did_ftplugin")
+    finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+if exists("loaded_matchit")
+    let b:match_ignorecase = 0
+    " Works okay, does not consider case when do is implicit (fn ->)
+    let b:match_words = '\<\%(do\|enum\)\>:\<end\>'
+    let b:match_skip = 's:syltComment\|syltString'
+endif " exists("loaded_matchit")
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/ftplugin/sy.vim
+++ b/ftplugin/sy.vim
@@ -17,5 +17,7 @@ if exists("loaded_matchit")
     let b:match_skip = 's:syltComment\|syltString'
 endif " exists("loaded_matchit")
 
+setlocal commentstring=//\ %s
+
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/indent/sy.vim
+++ b/indent/sy.vim
@@ -48,7 +48,7 @@ func! GetSyltIndent(line_num)
 
     let ident = prev_indent
 
-    if match(prev_codeline, '\(\<do\>\|[\|{\|(\)$') != -1
+    if match(prev_codeline, '\(\<\%(do\|enum\)\>\|[\|{\|(\)$') != -1
         let ident = ident + shiftwidth()
     endif
 

--- a/syntax/sy.vim
+++ b/syntax/sy.vim
@@ -16,8 +16,8 @@ if !exists("sylt_no_large_first_implies_type")
     syn match syltType /[A-Z][A-Za-z]\*/
 endif
 
-syn keyword syltKeyword if else loop break continue in blob yield ret
-                      \ fn use is do end and or not as external from
+syn keyword syltKeyword if else loop break continue in blob ret enum
+                      \ fn use is do end and or not as external from case
 
 syn match syltKeyword /->/
 syn match syltKeyword /::/

--- a/syntax/sy.vim
+++ b/syntax/sy.vim
@@ -19,6 +19,7 @@ endif
 
 syn keyword syltKeyword if else loop break continue in blob yield ret
 syn keyword syltKeyword fn use is do end and or not as external from
+syn keyword syltKeyword enum case
 
 syn match syltKeyword /->/
 syn match syltKeyword /::/
@@ -30,7 +31,7 @@ syn match syltNumber /\i\@<![-+]\?\d\+\%([eE][+-]\?\d\+\)\?/ display
 syn match syltFloat /\i\@<![-+]\?\d*\.\@<!\.\d\+\%([eE][+-]\?\d\+\)\?/ display
 syn match syltFloat /\i\@<![-+]\?\d+\.\@<!\.\d\*\%([eE][+-]\?\d\+\)\?/ display
 
-syn region syltBlock start="\<do\>" end="\<end\>" fold transparent
+syn region syltBlock start="\<\%(do\|enum\)\>" end="\<end\>" fold transparent
 syn region syltString start='"' end='"'
 
 syn keyword syltTodo contained TODO FIXME XXX NOTE
@@ -73,12 +74,12 @@ syn match syltOp /?/
 
 hi link syltOp       Operator
 
-syn match syltComment "//.*$" contains=syltTodo
+syn match syltComment "//.*$" contains=syltTodo,@Spell
 hi link syltComment     Comment
 
 " An error for trailing whitespace
 if !exists("sylt_no_trailing_space_error")
-  syn match syltSpaceError /\s\+$/ display
+  syn match syltSpaceError /\s\+\(\%#\)\@!$/ display
   hi def link syltSpaceError Error
 endif
 


### PR DESCRIPTION
- ftplugin
  - Adds matchit configuration, that matches do/enum with end. Works very badly.
  - Sets commentstring, so plugins like commentary.vim works.
- Enum is considered a block keyword, so it can be folded
- Enable spell checking inside comments
- Don't highlight trailing white space when inserting spaces in insert mode.

I don't know if the matchit thing is very useful so maybe it should go.